### PR TITLE
モバイル表示時のモノレールグラフの調整

### DIFF
--- a/pages/index.vue
+++ b/pages/index.vue
@@ -181,6 +181,7 @@ export default {
         'https://www.city.chiba.jp/hokenfukushi/iryoeisei/seisaku/covid-19/opendata.html',
       monorailGraphOption: {
         responsive: true,
+        maintainAspectRatio: false,
         legend: {
           display: true
         },


### PR DESCRIPTION
## 📝 関連issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- モバイルでみるとモノレールのグラフがつぶれちゃうので、調整しました。

## 📸 スクリーンショット / Screenshots

Before:
<img width="412" alt="Screen Shot 2020-08-08 at 15 59 23" src="https://user-images.githubusercontent.com/614339/89704621-4850e300-d990-11ea-97d2-9d18d2e9f34b.png">

After:
<img width="401" alt="Screen Shot 2020-08-08 at 15 59 55" src="https://user-images.githubusercontent.com/614339/89704625-4edf5a80-d990-11ea-8229-0f66f9040b12.png">
