### PR TITLE
検査陽性者の状況グラフ修正

### DIFF
--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -65,10 +65,13 @@
     />
     <text
       class="black text"
-      transform="translate(12 100)"
+      transform="translate(5 100)"
       :dx="getAdjustX(検査実施人数)"
     >
       <tspan>{{ 検査実施人数 }}</tspan>
+      <tspan class="unit" dx="-3" />
+    </text>
+    <text class="black text" transform="translate(20 115)">
       <tspan class="unit" dx="-3">人</tspan>
     </text>
     <mask id="path-10-inside-2" fill="white">


### PR DESCRIPTION
## 📝 関連issue / Related Issues
- close #215

## ⛏ 変更内容 / Details of Changes
- 検査実施人数が10,000人を超えてはみでるようになった部分を一旦改行して修正

## 📸 スクリーンショット / Screenshots
![image](https://user-images.githubusercontent.com/3695706/94364249-dfb9f300-0102-11eb-936a-9b3a894868f1.png)
