### PR TITLE
サイドナビゲーションの調整

### DIFF
--- a/components/SideNavigation.vue
+++ b/components/SideNavigation.vue
@@ -95,14 +95,10 @@ export default {
           divider: true,
         },
         {
+          icon: 'mdi-web',
           title: this.$t('Government special website'),
           link:
             'https://www.city.chiba.jp/hokenfukushi/iryoeisei/seisaku/kansensyoujyouhou.html',
-        },
-        {
-          icon: 'mdi-twitter',
-          title: this.$t('Twitter by mayor kumagai'),
-          link: 'https://twitter.com/kumagai_chiba',
         },
         {
           icon: 'mdi-twitter',
@@ -110,10 +106,13 @@ export default {
           link: 'https://twitter.com/Chiba_city_PR',
         },
         {
+          icon: 'mdi-information-outline',
           title: this.$t('About us'),
           link: '/about',
+          divider: true,
         },
         {
+          icon: 'mdi-link',
           title: this.$t('Chiba pref edition'),
           link: 'https://covid19.civictech.chiba.jp/',
           divider: true,


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #405 

## ⛏ 変更内容 / Details of Changes

- 熊谷元市長の Twitter へのリンクを削除
- 他サイドナビゲーションのアイテムでアイコンがないところに、それっぽいものを追加

## 📸 スクリーンショット / Screenshots

<img width="239" alt="Screen Shot 2021-03-16 at 16 49 35" src="https://user-images.githubusercontent.com/614339/111273828-a1e06500-8677-11eb-82e1-249444a96fce.png">
