### PR TITLE
まん防に関するリンクの追加

### DIFF
--- a/components/Information.vue
+++ b/components/Information.vue
@@ -1,0 +1,57 @@
+<template>
+  <v-card>
+    <v-card-title>
+      <v-icon size="24" left>mdi-alert-box-outline</v-icon>
+      インフォメーション
+    </v-card-title>
+    <v-card-text>
+      <ul>
+        <li>
+          4/28 〜 5/11 までまん延防止等重点措置が適用されます。詳細は
+          <a
+            class="ExternalLink"
+            href="https://www.pref.chiba.lg.jp/kenfuku/kansenshou/ncov/soti36.html"
+            target="_blank"
+            rel="noopener"
+          >
+            新型インフルエンザ等対策特別措置法に基づく協力要請等について
+            <v-icon class="ExternalLinkIcon" size="15">mdi-open-in-new</v-icon>
+          </a>
+          をご確認ください。
+        </li>
+        <li>
+          ワクチンについては
+          <a
+            class="ExternalLink"
+            href="https://www.city.chiba.jp/hokenfukushi/iryoeisei/seisaku/covid19-vaccine.html"
+            target="_blank"
+            rel="noopener"
+          >
+            新型コロナワクチン接種についてのお知らせ
+            <v-icon class="ExternalLinkIcon" size="15">mdi-open-in-new</v-icon>
+          </a>
+          をご確認ください。
+        </li>
+        <li>
+          最新のニュース等は
+          <a
+            class="ExternalLink"
+            href="https://www.city.chiba.jp/hokenfukushi/iryoeisei/seisaku/kansensyoujyouhou.html"
+            target="_blank"
+            rel="noopener"
+          >
+            千葉市の特設サイト
+            <v-icon class="ExternalLinkIcon" size="15">mdi-open-in-new</v-icon>
+          </a>
+          をご確認ください。
+        </li>
+      </ul>
+    </v-card-text>
+  </v-card>
+</template>
+
+<style scoped>
+ul {
+  line-height: 1.8;
+}
+</style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -6,33 +6,8 @@
       :date="headerItem.date"
     />
     <v-row>
-      <v-col cols="12" class="body-2">
-        <p>
-          最新のニュース等は
-          <a
-            class="ExternalLink"
-            href="https://www.city.chiba.jp/hokenfukushi/iryoeisei/seisaku/kansensyoujyouhou.html"
-            target="_blank"
-            rel="noopener"
-          >
-            千葉市の特設サイト
-            <v-icon class="ExternalLinkIcon" size="15">mdi-open-in-new</v-icon>
-          </a>
-          でご確認ください。
-        </p>
-        <p>
-          ワクチンについては
-          <a
-            class="ExternalLink"
-            href="https://www.city.chiba.jp/hokenfukushi/iryoeisei/seisaku/covid19-vaccine.html"
-            target="_blank"
-            rel="noopener"
-          >
-            新型コロナワクチン接種についてのお知らせ
-            <v-icon class="ExternalLinkIcon" size="15">mdi-open-in-new</v-icon>
-          </a>
-          でご確認ください。
-        </p>
+      <v-col cols="12">
+        <information />
       </v-col>
     </v-row>
     <v-row class="DataBlock">
@@ -135,6 +110,7 @@ import DataTable from '@/components/DataTable.vue'
 import DataView from '@/components/DataView.vue'
 import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
 import Contact from '@/components/Contact.vue'
+import Information from '@/components/Information.vue'
 
 import formatGraph from '@/utils/formatGraph'
 import formatTable from '@/utils/formatTable'
@@ -158,6 +134,7 @@ export default {
     DataView,
     ConfirmedCasesTable,
     Contact,
+    Information,
   },
   data() {
     // 感染者数グラフ


### PR DESCRIPTION
## 📝 関連issue / Related Issues

- close #471 

## ⛏ 変更内容 / Details of Changes

- まん防に関する情報へのリンクを追加(どうやら千葉県がとりまとめているみたいなので、そちらへ)
- 画面上部の情報が増えたので、1つのコンポーネントにしました

## 📸 スクリーンショット / Screenshots

<img width="1374" alt="Screen Shot 2021-04-26 at 16 08 40" src="https://user-images.githubusercontent.com/614339/116042703-b0279500-a6a9-11eb-99f7-6656a1194e23.png">

<img width="419" alt="Screen Shot 2021-04-26 at 16 08 09" src="https://user-images.githubusercontent.com/614339/116042652-a00fb580-a6a9-11eb-86cd-e094205c26c2.png">
