### PR TITLE
リトライ間隔とリトライ回数の設定追加

### DIFF
--- a/.github/workflows/convert_monorail.yml
+++ b/.github/workflows/convert_monorail.yml
@@ -61,6 +61,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MERGE_DELETE_BRANCH: true
+          MERGE_RETRIES: "10"
+          MERGE_RETRY_SLEEP: "60000"
 
       - name: Notify to slack
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/convert_monorail.yml
+++ b/.github/workflows/convert_monorail.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
## 👏 解決する issue / Resolved Issues
- close #577 

## ⛏ 変更内容 / Details of Changes
- NetlifyのDeploy終了を待ってPull Request Mergeを実行するように、
mergeable_state チェックのリトライ間隔とリトライ回数を追加した。
MERGE_RETRIES: "10"(回数)
MERGE_RETRY_SLEEP: "60000"(ms)

## その他
これでうまく動作することが確認できれば、GithubActionsの実行回数を日次から週次(毎週水曜)に変更し、無意味な実行回数を削減する予定。